### PR TITLE
Logic for "options" question type

### DIFF
--- a/src/javascripts/components/dashboard/questionBlock.js
+++ b/src/javascripts/components/dashboard/questionBlock.js
@@ -18,7 +18,7 @@ export default Vue.extend({
           v-if="question.type === 'options'"
           class="cc-questionBlock-bottom"
         >
-          <div v-for="option in options">
+          <div v-for="option in question.options" track-by="$index">
             <label class="cc-radioLabel">
               <input type="radio" :value="option" name="options">
               <span>{{ option }}</span>
@@ -30,7 +30,6 @@ export default Vue.extend({
   `,
   data() {
     return {
-      options: ['one', 'two', 'threeeeeeeee'],
       defaultText: '[Go to the edit panel to modify this question]',
       srcOfDragIcon: require('../../../images/drag.svg')
     };

--- a/src/javascripts/components/dashboard/rightPanel.js
+++ b/src/javascripts/components/dashboard/rightPanel.js
@@ -59,6 +59,7 @@ export default Vue.extend({
         @edit-text="editQuestionText"
         @add-option="addOption"
         @edit-option="editOption"
+        @delete-option="deleteOption"
       ></edit-panel>
     </div>
   `,
@@ -107,7 +108,11 @@ export default Vue.extend({
   // Vuex (state store) getters / action dispatchers needed by this component 
   vuex: {
     getters: {
-      survey(state) {return state.selectedSurvey;}
+      survey(state) {return state.selectedSurvey;},
+      currentQuestion(state) {
+        var survey = state.selectedSurvey;
+        return survey.questions[survey.currentQuestionIndex];
+      }
     },
     actions: {
       addQuestion(store, questionType) {
@@ -117,13 +122,18 @@ export default Vue.extend({
         store.dispatch('EDIT_QUESTION', 'text', text);
       },
       addOption() {
-        var optionsArray = [...this.survey.questions[this.survey.currentQuestionIndex].options]
+        var optionsArray = [...this.currentQuestion.options];
         optionsArray.push('');
         store.dispatch('EDIT_QUESTION', 'options', optionsArray);
       },
-      editOption(store, optionIndex, optionText) {
-        var optionsArray = [...this.survey.questions[this.survey.currentQuestionIndex].options];
-        optionsArray[optionIndex] = optionText;
+      editOption(store, index, optionText) {
+        var optionsArray = [...this.currentQuestion.options];
+        optionsArray[index] = optionText;
+        store.dispatch('EDIT_QUESTION', 'options', optionsArray);
+      },
+      deleteOption(store, index) {
+        var optionsArray = [...this.currentQuestion.options];
+        optionsArray.splice(index, 1);
         store.dispatch('EDIT_QUESTION', 'options', optionsArray);
       }
     }

--- a/src/javascripts/components/dashboard/rightPanel.js
+++ b/src/javascripts/components/dashboard/rightPanel.js
@@ -58,6 +58,7 @@ export default Vue.extend({
         :types="questionTypes"
         @edit-text="editQuestionText"
         @add-option="addOption"
+        @edit-option="editOption"
       ></edit-panel>
     </div>
   `,
@@ -113,17 +114,17 @@ export default Vue.extend({
         store.dispatch('ADD_QUESTION', questionType);
       },
       editQuestionText(store, text) {
-        console.log('in vuex dispatcher:', text);
         store.dispatch('EDIT_QUESTION', 'text', text);
       },
       addOption() {
-        console.log('in vuex dispatcher');
-        store.dispatch('EDIT_QUESTION', 'options', '');
+        var optionsArray = [...this.survey.questions[this.survey.currentQuestionIndex].options]
+        optionsArray.push('');
+        store.dispatch('EDIT_QUESTION', 'options', optionsArray);
       },
       editOption(store, optionIndex, optionText) {
-        store.dispatch('EDIT_QUESTION', 'options', [
-          ...this.survey.questions[this.survey.currentQuestionIndex], optionText
-        ]);
+        var optionsArray = [...this.survey.questions[this.survey.currentQuestionIndex].options];
+        optionsArray[optionIndex] = optionText;
+        store.dispatch('EDIT_QUESTION', 'options', optionsArray);
       }
     }
   }

--- a/src/javascripts/components/dashboard/rightPanel.js
+++ b/src/javascripts/components/dashboard/rightPanel.js
@@ -57,6 +57,7 @@ export default Vue.extend({
         :question="survey.questions[survey.currentQuestionIndex]"
         :types="questionTypes"
         @edit-text="editQuestionText"
+        @add-option="addOption"
       ></edit-panel>
     </div>
   `,
@@ -112,7 +113,17 @@ export default Vue.extend({
         store.dispatch('ADD_QUESTION', questionType);
       },
       editQuestionText(store, text) {
+        console.log('in vuex dispatcher:', text);
         store.dispatch('EDIT_QUESTION', 'text', text);
+      },
+      addOption() {
+        console.log('in vuex dispatcher');
+        store.dispatch('EDIT_QUESTION', 'options', '');
+      },
+      editOption(store, optionIndex, optionText) {
+        store.dispatch('EDIT_QUESTION', 'options', [
+          ...this.survey.questions[this.survey.currentQuestionIndex], optionText
+        ]);
       }
     }
   }

--- a/src/javascripts/components/dashboard/rightPanel/editOptions.js
+++ b/src/javascripts/components/dashboard/rightPanel/editOptions.js
@@ -3,8 +3,13 @@ import store from '../../../store.js';
 
 
 export default Vue.extend({
+  props: ['options'],
   template: `
-    <div v-for="(index, option) in options" class="cc-rightPanel-edit-row">
+    <div
+      v-for="(index, option) in options"
+      class="cc-rightPanel-edit-row"
+      track-by="$index"
+    >
       <label style="display: none" :for="'cc-optionInput' + index">smthign dynamic</label>
       <input
         type="text"
@@ -20,19 +25,19 @@ export default Vue.extend({
     <div class="cc-rightPanel-edit-row">
       <button
         class="cc-buttonReset cc-rightPanel-addOptionBtn"
-        @click.prevent
+        @click.prevent="addOption"
       >Add Option</button>
     </div>
   `,
   data() {
     return {
-      options: ['a','b','c'],
       srcForDeleteIcon: require('../../../../images/garbage.svg')
     };
   },
   methods: {
+    addOption() {console.log('adding');this.$dispatch('add-option');},
     editOption(event) {
-      this.$dispatch('updateOption', event.target.value);
+      this.$dispatch('update-option', event);
     }
   }
 });

--- a/src/javascripts/components/dashboard/rightPanel/editOptions.js
+++ b/src/javascripts/components/dashboard/rightPanel/editOptions.js
@@ -17,7 +17,7 @@ export default Vue.extend({
         class="cc-optionInput"
         :value="option"
         @input="editOption"
-        @keyup.enter.prevent
+        @keydown.enter.prevent="addOption"
         autocomplete="off"
       >
       <img
@@ -39,7 +39,12 @@ export default Vue.extend({
     };
   },
   methods: {
-    addOption() {this.$dispatch('add-option');},
+    addOption() {
+      this.$dispatch('add-option');
+      this.$nextTick(function() {
+        $('#cc-optionInput' + [this.options.length - 1]).focus();
+      });
+    },
     editOption(event) {
       var index = event.target.id[event.target.id.length - 1];
       var text = event.target.value;

--- a/src/javascripts/components/dashboard/rightPanel/editOptions.js
+++ b/src/javascripts/components/dashboard/rightPanel/editOptions.js
@@ -20,7 +20,11 @@ export default Vue.extend({
         @keyup.enter.prevent
         autocomplete="off"
       >
-      <img :src="srcForDeleteIcon" class="cc-rightPanel-garbageIcon">
+      <img
+        :src="srcForDeleteIcon"
+        class="cc-rightPanel-garbageIcon"
+        @click="deleteOption(index)"
+      >
     </div>
     <div class="cc-rightPanel-edit-row">
       <button
@@ -40,6 +44,9 @@ export default Vue.extend({
       var index = event.target.id[event.target.id.length - 1];
       var text = event.target.value;
       this.$dispatch('edit-option', index, text);
+    },
+    deleteOption(index) {
+      this.$dispatch('delete-option', index);
     }
   }
 });

--- a/src/javascripts/components/dashboard/rightPanel/editOptions.js
+++ b/src/javascripts/components/dashboard/rightPanel/editOptions.js
@@ -15,7 +15,7 @@ export default Vue.extend({
         type="text"
         :id="'cc-optionInput' + index"
         class="cc-optionInput"
-        :value="options[index]"
+        :value="option"
         @input="editOption"
         @keyup.enter.prevent
         autocomplete="off"
@@ -35,9 +35,11 @@ export default Vue.extend({
     };
   },
   methods: {
-    addOption() {console.log('adding');this.$dispatch('add-option');},
+    addOption() {this.$dispatch('add-option');},
     editOption(event) {
-      this.$dispatch('update-option', event);
+      var index = event.target.id[event.target.id.length - 1];
+      var text = event.target.value;
+      this.$dispatch('edit-option', index, text);
     }
   }
 });

--- a/src/javascripts/components/dashboard/rightPanelEdit.js
+++ b/src/javascripts/components/dashboard/rightPanelEdit.js
@@ -27,7 +27,9 @@ export default Vue.extend({
         </div>
         <edit-options
           v-if="question.type === 'options'"
-          @updateOption="handleTextInput(event)"
+          :options="question.options"
+          @add-option="emitEvent('add-option', '')"
+          @update-option="emitEvent(event)"
         ></edit-options>
       </form>
   `,
@@ -36,9 +38,11 @@ export default Vue.extend({
   },
   methods: {
     emitEvent(eventName, eventDetail) {
+      console.log('emitting:', eventName, typeof eventDetail);
       this.$dispatch(eventName, eventDetail);
     },
     handleTextInput(event) {
+      console.log('handling:', event.target.value);
       this.emitEvent('edit-text', event.target.value);
     }
   }

--- a/src/javascripts/components/dashboard/rightPanelEdit.js
+++ b/src/javascripts/components/dashboard/rightPanelEdit.js
@@ -32,8 +32,9 @@ export default Vue.extend({
         <edit-options
           v-if="question && question.type === 'options'"
           :options="question.options"
-          @add-option="emitEvent('add-option', '')"
+          @add-option="addOption"
           @edit-option="editOption"
+          @delete-option="deleteOption"
         ></edit-options>
       </form>
   `,
@@ -41,14 +42,17 @@ export default Vue.extend({
     'edit-options': editOptions
   },
   methods: {
-    emitEvent(eventName, eventDetails) {
-      this.$dispatch(eventName, eventDetails);
+    addOption() {
+      this.$dispatch('add-option');
     },
     handleTextInput(event) {
-      this.emitEvent('edit-text', event.target.value);
+      this.$dispatch('edit-text', event.target.value);
     },
     editOption(index, text) {
       this.$dispatch('edit-option', index, text);
+    },
+    deleteOption(index) {
+      this.$dispatch('delete-option', index);
     }
   }
 });

--- a/src/javascripts/components/dashboard/rightPanelEdit.js
+++ b/src/javascripts/components/dashboard/rightPanelEdit.js
@@ -12,9 +12,13 @@ export default Vue.extend({
   props: ['question'],
   template: `
       <form class="cc-rightPanel-edit">
+        <span v-show="!question" class="cc-editPanel-errorMsg">
+          Select a question from the center panel to edit!
+        </span>
         <div class="cc-rightPanel-edit-row">
           <label style="display: none" for="cc-editPanel-editText">Text</label>
           <input
+            v-if="question"
             type="text"
             :value="question.text || ''"
             class="cc-questionInput"
@@ -26,10 +30,10 @@ export default Vue.extend({
           >
         </div>
         <edit-options
-          v-if="question.type === 'options'"
+          v-if="question && question.type === 'options'"
           :options="question.options"
           @add-option="emitEvent('add-option', '')"
-          @update-option="emitEvent(event)"
+          @edit-option="editOption"
         ></edit-options>
       </form>
   `,
@@ -37,13 +41,14 @@ export default Vue.extend({
     'edit-options': editOptions
   },
   methods: {
-    emitEvent(eventName, eventDetail) {
-      console.log('emitting:', eventName, typeof eventDetail);
-      this.$dispatch(eventName, eventDetail);
+    emitEvent(eventName, eventDetails) {
+      this.$dispatch(eventName, eventDetails);
     },
     handleTextInput(event) {
-      console.log('handling:', event.target.value);
       this.emitEvent('edit-text', event.target.value);
+    },
+    editOption(index, text) {
+      this.$dispatch('edit-option', index, text);
     }
   }
 });

--- a/src/javascripts/services/surveyService.js
+++ b/src/javascripts/services/surveyService.js
@@ -9,6 +9,7 @@ export default (function() {
     var promise = new Promise((resolve, reject) => {
       if (user) {
         var finalQuestions = JSON.stringify(removeBlankQuestions(questions));
+        console.log('finalQuestions', finalQuestions);
         addSurveyToDatabase(title, finalQuestions, timestamp)
             .then((surveyId) => {
               if (surveyId) {
@@ -33,12 +34,6 @@ export default (function() {
             return false;
           }
         });
-  }
-  function addQuotes(questions) {
-    // Adding quotes to make it valid json for sending to database
-    return questions.map(function(question) {
-      return `"${question}"`;
-    });
   }
   function removeBlankQuestions(questions) {
     var filteredQuestions = questions;

--- a/src/javascripts/services/surveyService.js
+++ b/src/javascripts/services/surveyService.js
@@ -9,7 +9,6 @@ export default (function() {
     var promise = new Promise((resolve, reject) => {
       if (user) {
         var finalQuestions = JSON.stringify(removeBlankQuestions(questions));
-        console.log('finalQuestions', finalQuestions);
         addSurveyToDatabase(title, finalQuestions, timestamp)
             .then((surveyId) => {
               if (surveyId) {

--- a/src/javascripts/store.js
+++ b/src/javascripts/store.js
@@ -72,13 +72,24 @@ export default new Vuex.Store(function() {
       },
 
       EDIT_QUESTION: function(state, property, value) {
+        console.log('in store:', property);
         var currentIndex = state.selectedSurvey.currentQuestionIndex;
-        state.surveys.forEach((survey) => {
-          if (survey.id === state.selectedSurvey.id) {
-            survey.questions[currentIndex][property] = value;
-          }
-        });
-        state.selectedSurvey.questions[currentIndex][property] = value;
+        // state.surveys.forEach((survey) => {
+        //   if (survey.id === state.selectedSurvey.id) {
+        //     if (property === 'options' && value === '') {
+        //       survey.questions[currentIndex].options.push('');
+        //     } else {
+        //       survey.questions[currentIndex][property] = value;
+        //     }
+        //   }
+        // });
+        if (property === 'options' && value === '') {
+          console.log('about to push option, survey state:',
+            JSON.stringify(state.selectedSurvey.questions[currentIndex]));
+          state.selectedSurvey.questions[currentIndex].options.push('');
+        } else {
+          state.selectedSurvey.questions[currentIndex][property] = value;
+        }
       },
 
       EDIT_TITLE:  function(state, title) {

--- a/src/javascripts/store.js
+++ b/src/javascripts/store.js
@@ -61,62 +61,31 @@ export default new Vuex.Store(function() {
           questionToAdd.options = [];
         }
         var questionIndex = state.selectedSurvey.questions.length;
-        state.surveys.forEach(survey => {
-          if (survey.id === state.selectedSurvey.id) {
-            survey.questions.push(questionToAdd);
-            survey.currentQuestionIndex = questionIndex;
-          }
-        });
         state.selectedSurvey.questions.push(questionToAdd);
         state.selectedSurvey.currentQuestionIndex = questionIndex;
       },
 
       EDIT_QUESTION: function(state, property, value) {
-        console.log('in store:', property);
         var currentIndex = state.selectedSurvey.currentQuestionIndex;
-        // state.surveys.forEach((survey) => {
-        //   if (survey.id === state.selectedSurvey.id) {
-        //     if (property === 'options' && value === '') {
-        //       survey.questions[currentIndex].options.push('');
-        //     } else {
-        //       survey.questions[currentIndex][property] = value;
-        //     }
-        //   }
-        // });
-        if (property === 'options' && value === '') {
-          console.log('about to push option, survey state:',
-            JSON.stringify(state.selectedSurvey.questions[currentIndex]));
-          state.selectedSurvey.questions[currentIndex].options.push('');
-        } else {
-          state.selectedSurvey.questions[currentIndex][property] = value;
-        }
+        state.selectedSurvey.questions[currentIndex][property] = value;
       },
 
       EDIT_TITLE:  function(state, title) {
-        state.surveys.forEach((survey) => {
-          if (survey.id === state.selectedSurvey.id) {
-            survey.title = title;
-          }
-        });
         state.selectedSurvey.title = title;
       },
 
       SET_CURRENT_QUESTION_INDEX: function(state, index) {
-        state.surveys.forEach((survey) => {
-          if (survey.id === state.selectedSurvey.id) {
-            survey.currentQuestionIndex = index;
-          }
-        });
         state.selectedSurvey.currentQuestionIndex = index;
       },
 
       PUBLISH_SURVEY: function(state, surveyId, timestamp) {
         state.surveys.forEach((survey) => {
           if (survey.id === defaults.survey.id) {
+            survey.title = state.selectedSurvey.title;
             survey.isPublished = true;
             survey.id = surveyId;
             survey.timestamp = timestamp;
-            survey.questions = surveyService.removeBlankQuestions(survey.questions);
+            survey.questions = surveyService.removeBlankQuestions(state.selectedSurvey.questions);
             delete survey.isForPublishing;
           }
         });
@@ -124,6 +93,12 @@ export default new Vuex.Store(function() {
       },
 
       SET_SELECTED_SURVEY: function(state, survey = defaults.survey) {
+        // Updates previously selected survey in survey list, before changing it.
+        state.surveys.forEach((survey) => {
+          if (survey.id === state.selectedSurvey.id) {
+            survey = state.selectedSurvey;
+          }
+        });
         state.selectedSurvey = $.extend(true, {}, survey);
       },
 

--- a/src/stylesheets/rightPanelEdit.css
+++ b/src/stylesheets/rightPanelEdit.css
@@ -5,6 +5,7 @@ form.cc-rightPanel-edit {
   flex-direction: column;
   justify-content: flex-start;
   flex: 1;
+  overflow-y: auto;
 }
 
 .cc-editPanel-errorMsg {
@@ -17,6 +18,7 @@ form.cc-rightPanel-edit {
   width: 80%;
   margin: 12px auto;
   display: flex;
+  flex-shrink: 0;
   justify-content: center;
 }
 

--- a/src/stylesheets/rightPanelEdit.css
+++ b/src/stylesheets/rightPanelEdit.css
@@ -7,6 +7,12 @@ form.cc-rightPanel-edit {
   flex: 1;
 }
 
+.cc-editPanel-errorMsg {
+  color: #a4a4a4;
+  padding: 15px;
+  font-size: 12pt;
+}
+
 .cc-rightPanel-edit-row {
   width: 80%;
   margin: 12px auto;

--- a/src/stylesheets/surveyForm.css
+++ b/src/stylesheets/surveyForm.css
@@ -124,6 +124,10 @@ input.cc-titleInput:focus {
   border-top-color: #fff;
 }
 
+.cc-questionBlock-bottom label.cc-radioLabel {
+  font-size: 10pt;
+}
+
 .cc-submitSurveyFormBtn, .cc-addQuestionInputBtn, .cc-surveyForm-getLinkBtn {
   border-radius: 20px;
   color: #fff;


### PR DESCRIPTION
- only edit selected survey whenever changes are made
- make 'options' question type work (ie sync input with store)
- dispatch actions to higher level components, so they can communicate with vuex store
- able to delete options
- scroll right panel if too many options
